### PR TITLE
Use semantic contact links

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -29,16 +29,16 @@ const Footer = () => {
             <p className="text-primary-foreground/80 mb-6 leading-relaxed">
               Boutique consultancy creating high-performance, custom websites with strategic messaging that converts.
             </p>
-            <div className="space-y-2">
+            <address className="space-y-2 not-italic">
               <div className="flex items-center space-x-2 text-primary-foreground/80">
                 <Mail className="h-4 w-4" />
-                <span className="text-sm">hello@clearlinestudio.com</span>
+                <a href="mailto:hello@clearlinestudio.com" className="text-sm">hello@clearlinestudio.com</a>
               </div>
               <div className="flex items-center space-x-2 text-primary-foreground/80">
                 <Phone className="h-4 w-4" />
-                <span className="text-sm">(555) 987-6543</span>
+                <a href="tel:5559876543" className="text-sm">(555) 987-6543</a>
               </div>
-            </div>
+            </address>
           </div>
 
           {/* Services */}

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -134,9 +134,26 @@ const Contact = () => {
                   <CardDescription>Email, phone, and optional booking link.</CardDescription>
                 </CardHeader>
                 <CardContent className="space-y-3">
-                  <p><strong>Email:</strong> hello@clearlinestudio.com</p>
-                  <p><strong>Phone:</strong> (555) 987-6543</p>
-                  <p><a className="underline underline-offset-4" href={CALENDLY_URL} target="_blank" rel="noopener noreferrer">Open Calendly</a></p>
+                  <address className="space-y-3 not-italic">
+                    <p>
+                      <strong>Email:</strong>{' '}
+                      <a href="mailto:hello@clearlinestudio.com">hello@clearlinestudio.com</a>
+                    </p>
+                    <p>
+                      <strong>Phone:</strong>{' '}
+                      <a href="tel:5559876543">(555) 987-6543</a>
+                    </p>
+                  </address>
+                  <p>
+                    <a
+                      className="underline underline-offset-4"
+                      href={CALENDLY_URL}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      Open Calendly
+                    </a>
+                  </p>
                 </CardContent>
               </Card>
 


### PR DESCRIPTION
## Summary
- convert footer contact info spans to mailto and tel links wrapped in `address`
- use mailto and tel links in Contact page details card and wrap in `address`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 52 problems (45 errors, 7 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_689adaa7553883308f473bb89a6743fb